### PR TITLE
fix for WARNING: Title underline too short and WARNING: 

### DIFF
--- a/NCM6B.rst
+++ b/NCM6B.rst
@@ -1,7 +1,7 @@
 AI Accelerator
-#############
+##############
 NCM6B
-******
+*****
 -  PMIC (rk806)
 -  eMMC
 -  LPDDR4X
@@ -221,7 +221,7 @@ WiFi5/BT
       [DEL] Device B8:C6:AA:F9:6F:DF MiTV-AESP0 2755
 
 WiFi6/BT
--------
+--------
 
 -  **Check WiFi**
 

--- a/OpenAIA.rst
+++ b/OpenAIA.rst
@@ -8,7 +8,7 @@ U-Boot
 ~~~~~~
 
 Linux Kernel
-~~~~~~~~~~~
+~~~~~~~~~~~~
 
 Debos Recipe
 ~~~~~~~~~~~~

--- a/conf.py
+++ b/conf.py
@@ -67,7 +67,7 @@ release = 'master'
 #
 # This is also used if you do content translation via gettext catalogs.
 # Usually you set "language" from the command line for these cases.
-language = None
+language = 'en'
 
 # There are two options for replacing |today|: either, you set today to some
 # non-false value, then it is used:

--- a/quick.rst
+++ b/quick.rst
@@ -2,7 +2,7 @@ Getting Started
 ---------------
 
 Introduction
-~~~~~~~~~~~
+~~~~~~~~~~~~
 
 Prerequisites
 ~~~~~~~~~~~~~


### PR DESCRIPTION
fix for WARNING: Title underline too short and WARNING: Invalid configuration value found: 'language = None'.